### PR TITLE
refactor: change provider db to postgres

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
This pull request updates the database configuration in the Prisma schema to use PostgreSQL instead of SQLite.

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL6-R6): Changed the `provider` in the `datasource db` block from `"sqlite"` to `"postgresql"`, aligning the schema with a PostgreSQL database.